### PR TITLE
Prevent accidental bool conversion of AutoCloseFd.

### DIFF
--- a/c++/src/kj/io.h
+++ b/c++/src/kj/io.h
@@ -257,6 +257,10 @@ public:
   inline operator int() const { return fd; }
   inline int get() const { return fd; }
 
+  operator bool() const = delete;
+  // Deleting this operator prevents accidental use in boolean contexts, which
+  // the int conversion operator above would otherwise allow.
+
   inline bool operator==(decltype(nullptr)) { return fd < 0; }
   inline bool operator!=(decltype(nullptr)) { return fd >= 0; }
 


### PR DESCRIPTION
Without this change, the following code compiles:

    kj::AutoCloseFd fd;
    if (!fd) return;

In my opinion, this is a bit dangerous, although I could easily agree that it's too much of a corner case to waste header space on.